### PR TITLE
Remove unused import that is throwing deprecation warnings

### DIFF
--- a/src/scarap/callers.py
+++ b/src/scarap/callers.py
@@ -5,7 +5,6 @@ import shutil
 import subprocess
 import sys
 
-from Bio.Align.Applications import MafftCommandline
 from pathlib import Path
 
 from scarap.utils import *


### PR DESCRIPTION
The Bio.Application module won't be maintained anymore and importing it in current releases raises warnings. It is not being used in this script so should be fine to remove the import.

source: https://biopython.org/docs/dev/api/Bio.Application.html