### PR TITLE
Use Seq to initialize empty sequence

### DIFF
--- a/src/scarap/computers.py
+++ b/src/scarap/computers.py
@@ -398,7 +398,7 @@ def construct_supermatrix(coregenome, alifins, supermatrixfout):
     genomes = list(set(coregenome.genome))
     n_genomes = len(genomes)
     for genome in genomes:
-        supermatrix[genome] = SeqRecord.SeqRecord(id = genome, seq = "",
+        supermatrix[genome] = SeqRecord.SeqRecord(id = genome, seq = SeqRecord.Seq(""),
             description = "")
 
     alifindict = {filename_from_path(alifin): alifin for alifin in alifins}


### PR DESCRIPTION
To handle this deprecation warning thrown by Biopython: 
```
BiopythonDeprecationWarning: Using a string as the sequence is deprecated and will raise a TypeError in future. It has been converted to a Seq object.
```